### PR TITLE
Fix for Telegram (maybe others) by falling back on `ActiveWindow.getFrontmost`

### DIFF
--- a/Moves/WindowHandler.swift
+++ b/Moves/WindowHandler.swift
@@ -28,7 +28,14 @@ class WindowHandler {
     }
 
     let loc = Mouse.location()
-    guard let window = AccessibilityElement.at(loc)?.window else { return }
+
+    let window: AccessibilityElement
+    if let w = AccessibilityElement.at(loc)?.window {
+      window = w
+    } else {
+      guard let fallback = ActiveWindow.getFrontmost() else { return }
+      window = fallback
+    }
 
     let app = window.application
 


### PR DESCRIPTION
Hey Mikkel! I'm using Telegram, and Moves never worked on it. I asked Claude to take a look and this is the fix, working on the `12.5.278821 AppStore` version of Telegram.

Seems like this kind of fallback behavior might also be useful for other Apps that have some kind of incompatible accessibility setup.