### PR TITLE
Continue window detection fixes

### DIFF
--- a/Moves.xcodeproj/project.pbxproj
+++ b/Moves.xcodeproj/project.pbxproj
@@ -474,7 +474,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				INFOPLIST_FILE = Moves/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = Moves;
+				INFOPLIST_KEY_CFBundleDisplayName = "Moves Dev";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(LD_RUNPATH_SEARCH_PATHS_$(IS_MACCATALYST))",
@@ -484,8 +484,10 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MARKETING_VERSION = 1.9.1;
-				PRODUCT_BUNDLE_IDENTIFIER = com.brnbw.Moves;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				MOVES_URL_NAME = com.brnbw.moves.dev;
+				MOVES_URL_SCHEME = "moves-dev";
+				PRODUCT_BUNDLE_IDENTIFIER = com.brnbw.Moves.dev;
+				PRODUCT_NAME = "Moves Dev";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -513,6 +515,8 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MARKETING_VERSION = 1.9.1;
+				MOVES_URL_NAME = com.brnbw.moves;
+				MOVES_URL_SCHEME = moves;
 				PRODUCT_BUNDLE_IDENTIFIER = com.brnbw.Moves;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -536,7 +540,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.brnbw.MovesTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Moves.app/Contents/MacOS/Moves";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Moves Dev.app/Contents/MacOS/Moves Dev";
 			};
 			name = Debug;
 		};

--- a/Moves/Info.plist
+++ b/Moves/Info.plist
@@ -24,10 +24,10 @@
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>CFBundleURLName</key>
-			<string>com.brnbw.moves</string>
+			<string>$(MOVES_URL_NAME)</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>moves</string>
+				<string>$(MOVES_URL_SCHEME)</string>
 			</array>
 		</dict>
 	</array>

--- a/Moves/WindowHandler.swift
+++ b/Moves/WindowHandler.swift
@@ -28,14 +28,7 @@ class WindowHandler {
     }
 
     let loc = Mouse.location()
-
-    let window: AccessibilityElement
-    if let w = AccessibilityElement.at(loc)?.window {
-      window = w
-    } else {
-      guard let fallback = ActiveWindow.getFrontmost() else { return }
-      window = fallback
-    }
+    guard let window = window(at: loc) else { return }
 
     let app = window.application
 
@@ -78,6 +71,93 @@ class WindowHandler {
         return event
       }
     )
+  }
+
+  private func window(at loc: CGPoint) -> AccessibilityElement? {
+    let element = AccessibilityElement.at(loc)
+
+    if let window = element?.window {
+      return window
+    }
+
+    if let onScreenWindow = onScreenWindow(at: loc),
+      let window = window(matching: onScreenWindow, at: loc)
+    {
+      return window
+    }
+
+    if let app = element?.application,
+      let window = window(containing: loc, in: app)
+    {
+      return window
+    }
+
+    guard let fallback = ActiveWindow.getFrontmost(), contains(loc, in: fallback) else { return nil }
+    return fallback
+  }
+
+  private func onScreenWindow(at loc: CGPoint) -> OnScreenWindow? {
+    guard
+      let windowList =
+        CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID)
+        as? [[String: Any]]
+    else { return nil }
+
+    return windowList.lazy
+      .compactMap { info in
+        guard let pid = (info[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value else { return nil }
+        guard let layer = (info[kCGWindowLayer as String] as? NSNumber)?.intValue, layer == 0 else {
+          return nil
+        }
+        guard let alpha = (info[kCGWindowAlpha as String] as? NSNumber)?.doubleValue, alpha > 0 else {
+          return nil
+        }
+        guard let bounds = CGRect.dictionary(info[kCGWindowBounds as String]) else { return nil }
+        return OnScreenWindow(pid: pid, bounds: bounds)
+      }
+      .first { $0.bounds.contains(loc) }
+  }
+
+  private func window(matching onScreenWindow: OnScreenWindow, at loc: CGPoint) -> AccessibilityElement? {
+    guard let app = Application(forProcessID: onScreenWindow.pid) else { return nil }
+
+    let matchingWindow = windows(in: app)
+      .compactMap { window -> (AccessibilityElement, CGFloat)? in
+        guard let frame = frame(of: window), frame.intersects(onScreenWindow.bounds) else { return nil }
+        return (window, frameDistance(frame, onScreenWindow.bounds))
+      }
+      .min { $0.1 < $1.1 }?
+      .0
+
+    if let matchingWindow {
+      return matchingWindow
+    }
+
+    return window(containing: loc, in: app)
+  }
+
+  private func window(containing loc: CGPoint, in app: Application) -> AccessibilityElement? {
+    windows(in: app).first { contains(loc, in: $0) }
+  }
+
+  private func windows(in app: Application) -> [AccessibilityElement] {
+    guard let windows: [AXUIElement] = try? app.attribute(.windows) else { return [] }
+    return windows.map { AccessibilityElement(ref: UIElement($0)) }
+  }
+
+  private func frame(of window: AccessibilityElement) -> CGRect? {
+    guard let origin = window.position, let size = window.size else { return nil }
+    return CGRect(origin: origin, size: size)
+  }
+
+  private func contains(_ loc: CGPoint, in window: AccessibilityElement) -> Bool {
+    guard let frame = frame(of: window) else { return false }
+    return frame.contains(loc)
+  }
+
+  private func frameDistance(_ lhs: CGRect, _ rhs: CGRect) -> CGFloat {
+    abs(lhs.minX - rhs.minX) + abs(lhs.minY - rhs.minY) + abs(lhs.width - rhs.width)
+      + abs(lhs.height - rhs.height)
   }
 
   private func getBundleID(for axApplication: AXUIElement) -> String? {
@@ -172,6 +252,18 @@ class WindowHandler {
     window.resizeTo(CGSize(width: newMaxX - newMinX, height: newMaxY - newMinY))
   }
 
+}
+
+private struct OnScreenWindow {
+  let pid: pid_t
+  let bounds: CGRect
+}
+
+private extension CGRect {
+  static func dictionary(_ value: Any?) -> CGRect? {
+    guard let dictionary = value as? NSDictionary else { return nil }
+    return CGRect(dictionaryRepresentation: dictionary)
+  }
 }
 
 private enum ResizeAxisEdge {

--- a/Moves/WindowHandler.swift
+++ b/Moves/WindowHandler.swift
@@ -28,7 +28,14 @@ class WindowHandler {
     }
 
     let loc = Mouse.location()
-    guard let window = AccessibilityElement.at(loc)?.window else { return }
+
+    let window: AccessibilityElement
+    if let w = AccessibilityElement.at(loc)?.window {
+      window = w
+    } else {
+      guard let fallback = ActiveWindow.getFrontmost() else { return }
+      window = fallback
+    }
 
     let app = window.application
 


### PR DESCRIPTION
Continuation of #20.
Closes #20

This picks up where that PR left off:
- add inactive window detection using CGWindowList fallback + AX remapping
- keep frontmost fallback gated by cursor position
- separate Debug app metadata from Release so local dev and release builds can coexist cleanly

Built locally:
- xcodebuild -scheme Moves -configuration Debug build
- xcodebuild -scheme Moves -configuration Release build