### PR TITLE
Fix excluded apps not being honored

### DIFF
--- a/Moves/WindowHandler.swift
+++ b/Moves/WindowHandler.swift
@@ -33,7 +33,7 @@ class WindowHandler {
     let app = window.application
 
     if let path = applicationPath(app: app),
-      Defaults[.excludedApplicationPaths].contains(path)
+      AppExclusion.isExcluded(path, in: Defaults[.excludedApplicationPaths])
     {
       return
     }
@@ -192,8 +192,7 @@ class WindowHandler {
       print("no url")
       return nil
     }
-    let path = url.path
-    return path.hasSuffix("/") ? path : path.appending("/")
+    return url.path
   }
 
   private func mouseMoved(_ event: NSEvent) {
@@ -261,6 +260,17 @@ class WindowHandler {
     window.resizeTo(CGSize(width: newMaxX - newMinX, height: newMaxY - newMinY))
   }
 
+}
+
+enum AppExclusion {
+  static func isExcluded(_ path: String, in excludedPaths: Set<String>) -> Bool {
+    let normalized = normalize(path)
+    return excludedPaths.contains { normalize($0) == normalized }
+  }
+
+  static func normalize(_ path: String) -> String {
+    path.hasSuffix("/") ? String(path.dropLast()) : path
+  }
 }
 
 private struct OnScreenWindow {

--- a/MovesTests/MovesTests.swift
+++ b/MovesTests/MovesTests.swift
@@ -20,4 +20,28 @@ class MovesTests: XCTestCase {
 
     assert(result == "/Applications/Xcode.app")
   }
+
+  func testExclusionMatchesPathsStoredWithoutTrailingSlash() {
+    let excluded: Set<String> = ["/Applications/Adobe InDesign 2025/Adobe InDesign 2025.app"]
+
+    XCTAssertTrue(
+      AppExclusion.isExcluded(
+        "/Applications/Adobe InDesign 2025/Adobe InDesign 2025.app", in: excluded))
+    XCTAssertTrue(
+      AppExclusion.isExcluded(
+        "/Applications/Adobe InDesign 2025/Adobe InDesign 2025.app/", in: excluded))
+  }
+
+  func testExclusionMatchesLegacyPathsStoredWithTrailingSlash() {
+    let excluded: Set<String> = ["/Applications/Xcode.app/"]
+
+    XCTAssertTrue(AppExclusion.isExcluded("/Applications/Xcode.app", in: excluded))
+    XCTAssertTrue(AppExclusion.isExcluded("/Applications/Xcode.app/", in: excluded))
+  }
+
+  func testExclusionDoesNotMatchOtherApps() {
+    let excluded: Set<String> = ["/Applications/Xcode.app/"]
+
+    XCTAssertFalse(AppExclusion.isExcluded("/Applications/Safari.app", in: excluded))
+  }
 }


### PR DESCRIPTION
Fixes #25

## The bug

The SwiftUI excludes pane (`ExcludesSettingsPane`) stores excluded apps as `URL.path`, which has **no** trailing slash:

```
/Applications/Adobe InDesign 2025/Adobe InDesign 2025.app
```

But `WindowHandler.applicationPath` appended a trailing slash before checking membership:

```swift
return path.hasSuffix("/") ? path : path.appending("/")
```

So the `contains` check compared `/…/Adobe InDesign 2025.app/` against a set holding `/…/Adobe InDesign 2025.app` — it never matched, and exclusions added through the current settings UI were silently ignored.

The trailing-slash convention dates back to the original `ExcludesViewController`, which derived paths from `file://` URL strings (directory URLs end in `/`). The regression appeared when the settings UI was rewritten in SwiftUI and switched to `URL.path`.

## The fix

Normalize the trailing slash on both sides of the comparison (`AppExclusion.isExcluded`), so entries stored in either format — legacy with slash, current without — match correctly. No migration needed.

Added unit tests covering both stored formats plus a negative case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)